### PR TITLE
Replace discordbots.org with top.gg

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2019 Assanali Mukhanov & discordbots.org
+Copyright 2019 Assanali Mukhanov & top.gg
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ DBL Python Library
    :target: https://dblpy.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation Status
 
-A simple API wrapper for `discordbots.org`_ written in Python
+A simple API wrapper for `top.gg`_ written in Python
 
 Installation
 ------------
@@ -39,7 +39,7 @@ Features
 * GET bot info, server count, upvote info
 * GET all bots
 * GET user info
-* GET widgets (large and small) including custom ones. See `discordbots.org/api/docs`_ for more info.
+* GET widgets (large and small) including custom ones. See `top.gg/api/docs`_ for more info.
 * GET weekend status
 * Built-in webhook to help you handle DBL upvotes
 * Automated server count posting
@@ -67,7 +67,7 @@ Without webhook:
 
 
     class DBLAPI(commands.Cog):
-        """Handles interactions with the discordbots.org API"""
+        """Handles interactions with the top.gg API"""
 
         def __init__(self, bot):
             self.bot = bot
@@ -109,7 +109,7 @@ With webhook:
 
 
     class DBLAPI(commands.Cog):
-        """Handles interactions with the discordbots.org API"""
+        """Handles interactions with the top.gg API"""
 
         def __init__(self, bot):
             self.bot = bot
@@ -153,7 +153,7 @@ With autopost:
 
 
     class DBLAPI(commands.Cog):
-        """Handles interactions with the discordbots.org API"""
+        """Handles interactions with the top.gg API"""
 
         def __init__(self, bot):
             self.bot = bot
@@ -166,6 +166,6 @@ With autopost:
     def setup(bot):
         bot.add_cog(DBLAPI(bot))
 
-.. _discordbots.org: https://discordbots.org/
-.. _discordbots.org/api/docs: https://discordbots.org/api/docs
+.. _top.gg: https://top.gg/
+.. _top.gg/api/docs: https://top.gg/api/docs
 .. _here: https://dblpy.rtfd.io

--- a/dbl/__init__.py
+++ b/dbl/__init__.py
@@ -3,8 +3,8 @@
 """
 DBL Python API Wrapper
 ~~~~~~~~~~~~~~~~~~~~~~
-A basic wrapper for the discordbots.org API.
-:copyright: (c) 2019 Assanali Mukhanov & discordbots.org
+A basic wrapper for the top.gg API.
+:copyright: (c) 2019 Assanali Mukhanov & top.gg
 :license: MIT, see LICENSE for more details.
 """
 

--- a/dbl/client.py
+++ b/dbl/client.py
@@ -34,7 +34,7 @@ log = logging.getLogger(__name__)
 
 
 class DBLClient:
-    """Represents a client connection that connects to discordbots.org.
+    """Represents a client connection that connects to top.gg.
     This class is used to interact with the DBL API.
 
     .. _event loop: https://docs.python.org/3/library/asyncio-eventloops.html
@@ -95,7 +95,7 @@ class DBLClient:
     async def get_weekend_status(self):
         """This function is a coroutine.
 
-        Gets weekend status from discordbots.org
+        Gets weekend status from top.gg
 
         Returns
         =======
@@ -114,7 +114,7 @@ class DBLClient:
     ):
         """This function is a coroutine.
 
-        Posts your bot's guild count to discordbots.org
+        Posts your bot's guild count to top.gg
 
         .. _0 based indexing : https://en.wikipedia.org/wiki/Zero-based_numbering
 
@@ -132,7 +132,7 @@ class DBLClient:
     async def get_guild_count(self, bot_id: int = None):
         """This function is a coroutine.
 
-        Gets a guild count from discordbots.org
+        Gets a guild count from top.gg
 
         Parameters
         ==========
@@ -156,7 +156,7 @@ class DBLClient:
     async def get_bot_upvotes(self):
         """This function is a coroutine.
 
-        Gets information about last 1000 votes for your bot on discordbots.org
+        Gets information about last 1000 votes for your bot on top.gg
 
         .. note::
 
@@ -175,7 +175,7 @@ class DBLClient:
     async def get_bot_info(self, bot_id: int = None):
         """This function is a coroutine.
 
-        Gets information about a bot from discordbots.org
+        Gets information about a bot from top.gg
 
         Parameters
         ==========
@@ -188,7 +188,7 @@ class DBLClient:
 
         bot info: dict
             Information on the bot you looked up.
-            https://discordbots.org/api/docs#bots
+            https://top.gg/api/docs#bots
         """
         await self._ensure_bot_user()
         if bot_id is None:
@@ -198,7 +198,7 @@ class DBLClient:
     async def get_bots(self, limit: int = 50, offset: int = 0, sort: str = None, search: dict = None, fields: list = None):
         """This function is a coroutine.
 
-        Gets information about listed bots on discordbots.org
+        Gets information about listed bots on top.gg
 
         Parameters
         ==========
@@ -219,7 +219,7 @@ class DBLClient:
 
         bots: dict
             Returns info on the bots on DBL.
-            https://discordbots.org/api/docs#bots
+            https://top.gg/api/docs#bots
         """
         sort = sort or "" # weird but works
         search = search or {}
@@ -230,7 +230,7 @@ class DBLClient:
     async def get_user_info(self, user_id: int):
         """This function is a coroutine.
 
-        Gets information about a user on discordbots.org
+        Gets information about a user on top.gg
 
         Parameters
         ==========
@@ -243,7 +243,7 @@ class DBLClient:
 
         user data: dict
             Info about the user.
-            https://discordbots.org/api/docs#users
+            https://top.gg/api/docs#users
         """
         await self._ensure_bot_user()
         return await self.http.get_user_info(user_id)
@@ -251,7 +251,7 @@ class DBLClient:
     async def get_user_vote(self, user_id: int):
         """This function is a coroutine.
 
-        Gets information about the user's upvote for your bot on discordbots.org
+        Gets information about the user's upvote for your bot on top.gg
 
         Parameters
         ==========
@@ -310,7 +310,7 @@ class DBLClient:
         URL of the widget: str
         """
         await self._ensure_bot_user()
-        url = 'https://discordbots.org/api/widget/{0}.png?topcolor={1}&middlecolor={2}&usernamecolor={3}&certifiedcolor={4}&datacolor={5}&labelcolor={6}&highlightcolor={7}'
+        url = 'https://top.gg/api/widget/{0}.png?topcolor={1}&middlecolor={2}&usernamecolor={3}&certifiedcolor={4}&datacolor={5}&labelcolor={6}&highlightcolor={7}'
         if bot_id is None:
             bot_id = self.bot_id
         url = url.format(bot_id, top, mid, user, cert, data, label, highlight)
@@ -335,7 +335,7 @@ class DBLClient:
         await self._ensure_bot_user()
         if bot_id is None:
             bot_id = self.bot_id
-        url = 'https://discordbots.org/api/widget/{0}.png'.format(bot_id)
+        url = 'https://top.gg/api/widget/{0}.png'.format(bot_id)
         return url
 
     async def generate_widget_small(
@@ -373,7 +373,7 @@ class DBLClient:
         URL of the widget: str
         """
         await self._ensure_bot_user()
-        url = 'https://discordbots.org/api/widget/lib/{0}.png?avatarbg={1}&lefttextcolor={2}&righttextcolor={3}&leftcolor={4}&rightcolor={5}'
+        url = 'https://top.gg/api/widget/lib/{0}.png?avatarbg={1}&lefttextcolor={2}&righttextcolor={3}&leftcolor={4}&rightcolor={5}'
         if bot_id is None:
             bot_id = self.bot_id
         url = url.format(bot_id, avabg, ltxt, rtxt, lcol, rcol)
@@ -398,7 +398,7 @@ class DBLClient:
         await self._ensure_bot_user()
         if bot_id is None:
             bot_id = self.bot_id
-        url = 'https://discordbots.org/api/widget/lib/{0}.png'.format(bot_id)
+        url = 'https://top.gg/api/widget/lib/{0}.png'.format(bot_id)
         return url
 
     async def webhook(self):

--- a/dbl/http.py
+++ b/dbl/http.py
@@ -62,7 +62,7 @@ class HTTPClient:
     """
 
     def __init__(self, token, **kwargs):
-        self.BASE = 'https://discordbots.org/api'
+        self.BASE = 'https://top.gg/api'
         self.token = token
         self.loop = asyncio.get_event_loop() if kwargs.get('loop') is None else kwargs.get('loop')
         self.session = kwargs.get('session') or aiohttp.ClientSession(loop=kwargs.get('loop'))

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -34,11 +34,11 @@ Event reference
 
 .. function:: on_guild_post()
 
-    Called when guild count is posted on discordbots.org
+    Called when guild count is posted on top.gg
 
 .. function:: on_dbl_vote(data)
 
-    Called when someone votes for your bot on discordbots.org
+    Called when someone votes for your bot on top.gg
 
     :param data: The data with vote info returned in dict object
 
@@ -50,11 +50,11 @@ Event reference
 
     The data returned can be found `here`_.
 
-    .. _here: https://discordbots.org/api/docs#webhooks
+    .. _here: https://top.gg/api/docs#webhooks
 
 .. function:: on_dbl_test(data)
 
-    Called when someone tests webhook system for your bot on discordbots.org
+    Called when someone tests webhook system for your bot on top.gg
 
     :param data: The data with test info returned in dict object
 
@@ -66,7 +66,7 @@ Event reference
 
     The data returned can be found `here`_.
 
-    .. _here: https://discordbots.org/api/docs#webhooks
+    .. _here: https://top.gg/api/docs#webhooks
 
 Exceptions
 ----------

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -79,10 +79,10 @@ Initial release
     * GET bot info, server count, upvote count, upvote info
     * GET all bots
     * GET specific user info
-    * GET widgets (large and small) including custom ones. See `discordbots.org/api/docs`_ for more info.
+    * GET widgets (large and small) including custom ones. See `top.gg/api/docs`_ for more info.
 
 * Not Working / Implemented
 
     * Searching for bots via the api
 
-.. _discordbots.org/api/docs: https://discordbots.org/api/docs
+.. _top.gg/api/docs: https://top.gg/api/docs

--- a/setup.py
+++ b/setup.py
@@ -21,13 +21,13 @@ with open('README.rst') as f:
     readme = f.read()
 
 setup(name='dblpy',
-      author='Assanali Mukhanov, discordbots.org',
+      author='Assanali Mukhanov, top.gg',
       author_email='shivaco.osu@gmail.com',
       url='https://github.com/DiscordBotList/DBL-Python-Library',
       version=version,
       packages=find_packages(),
       license='MIT',
-      description='A simple API wrapper for discordbots.org written in Python',
+      description='A simple API wrapper for top.gg written in Python',
       long_description=readme,
       include_package_data=True,
       python_requires='>= 3.5.3',


### PR DESCRIPTION
## Proposed Changes

  - Replaces the old discordbots.org domain with the new top.gg domain.
